### PR TITLE
Aliased imports

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -102,7 +102,7 @@ class DependenciesPlugin {
           let effectiveDep = dep;
 
           if (this.options.moduleDirectoryMatch.test(dep.module.resource) && dep.name) {
-            const redirectedTo = dep.module.dependencies.find(l2dep => l2dep.name === dep.name);
+            const redirectedTo = dep.module.dependencies.find(l2dep => l2dep.name === dep.id && l2dep.module);
             if (redirectedTo) {
               effectiveDep = redirectedTo;
             }


### PR DESCRIPTION
This is an extension of the previous PR to fix a couple of issues

1. In one of my larger projects, there is a match for a second level dependency with `l2dep.module = undefined`.  This breaks some of the later code - so the PR adds a check to ensure this is set
2. In case you do an `import { Component as ComponentB } from 'xyz'` the previous code was trying to look for an export named `ComponentB` as we were matching with `dep.name`. `dep.id` has the value of `Component` in this case - so it's more accurate to match on `id`